### PR TITLE
chore: Ratelimiter is enabled by default

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -38,9 +38,9 @@ const (
 	defaultEtcdKeyPath          = ""
 	defaultEtcdCertPath         = ""
 
+	defaultEnableLimiter          bool  = true
 	defaultInitialLimiterCapacity int   = 100 * 1000
 	defaultInitialLimiterRate     int   = 10 * 1000
-	defaultEnableLimiter          bool  = false
 	defaultEtcdStartTimeoutMs     int64 = 60 * 1000
 	defaultCallTimeoutMs                = 5 * 1000
 	defaultEtcdMaxTxnOps                = 128
@@ -95,12 +95,12 @@ const (
 )
 
 type LimiterConfig struct {
+	// Enable is used to control the switch of the limiter.
+	Enable bool `toml:"enable" env:"FLOW_LIMITER_ENABLE"`
 	// Limit is the updated rate of tokens.
 	Limit int `toml:"limit" env:"FLOW_LIMITER_LIMIT"`
 	// Burst is the maximum number of tokens.
 	Burst int `toml:"burst" env:"FLOW_LIMITER_BURST"`
-	// Enable is used to control the switch of the limiter.
-	Enable bool `toml:"enable" env:"FLOW_LIMITER_ENABLE"`
 }
 
 // Config is server start config, it has three input modes:
@@ -294,9 +294,9 @@ func MakeConfigParser() (*Parser, error) {
 			File:  log.DefaultLogFile,
 		},
 		FlowLimiter: LimiterConfig{
+			Enable: defaultEnableLimiter,
 			Limit:  defaultInitialLimiterRate,
 			Burst:  defaultInitialLimiterCapacity,
-			Enable: defaultEnableLimiter,
 		},
 
 		EnableEmbedEtcd: defaultEnableEmbedEtcd,

--- a/server/limiter/limiter.go
+++ b/server/limiter/limiter.go
@@ -24,26 +24,26 @@ import (
 )
 
 type FlowLimiter struct {
-	l *rate.Limiter
+	// enable is used to control the switch of the limiter.
+	enable bool
+	l      *rate.Limiter
 	// RWMutex is used to protect following fields.
 	lock sync.RWMutex
 	// limit is the updated rate of tokens.
 	limit int
 	// burst is the maximum number of tokens.
 	burst int
-	// enable is used to control the switch of the limiter.
-	enable bool
 }
 
 func NewFlowLimiter(config config.LimiterConfig) *FlowLimiter {
 	newLimiter := rate.NewLimiter(rate.Limit(config.Limit), config.Burst)
 
 	return &FlowLimiter{
+		enable: config.Enable,
 		l:      newLimiter,
 		lock:   sync.RWMutex{},
 		limit:  config.Limit,
 		burst:  config.Burst,
-		enable: config.Enable,
 	}
 }
 
@@ -58,18 +58,18 @@ func (f *FlowLimiter) UpdateLimiter(config config.LimiterConfig) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	f.enable = config.Enable
 	f.l.SetLimit(rate.Limit(config.Limit))
 	f.l.SetBurst(config.Burst)
 	f.limit = config.Limit
 	f.burst = config.Burst
-	f.enable = config.Enable
 	return nil
 }
 
 func (f *FlowLimiter) GetConfig() *config.LimiterConfig {
 	return &config.LimiterConfig{
+		Enable: f.enable,
 		Limit:  f.limit,
 		Burst:  f.burst,
-		Enable: f.enable,
 	}
 }

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -371,9 +371,9 @@ func (a *API) updateFlowLimiter(req *http.Request) apiFuncResult {
 	log.Info("update flow limiter request", zap.String("request", fmt.Sprintf("%+v", updateFlowLimiterRequest)))
 
 	newLimiterConfig := config.LimiterConfig{
+		Enable: updateFlowLimiterRequest.Enable,
 		Limit:  updateFlowLimiterRequest.Limit,
 		Burst:  updateFlowLimiterRequest.Burst,
-		Enable: updateFlowLimiterRequest.Enable,
 	}
 
 	if err := a.flowLimiter.UpdateLimiter(newLimiterConfig); err != nil {

--- a/server/service/http/types.go
+++ b/server/service/http/types.go
@@ -148,9 +148,9 @@ type UpdateClusterRequest struct {
 }
 
 type UpdateFlowLimiterRequest struct {
+	Enable bool `json:"enable"`
 	Limit  int  `json:"limit"`
 	Burst  int  `json:"burst"`
-	Enable bool `json:"enable"`
 }
 
 type UpdateDeployModeRequest struct {


### PR DESCRIPTION
## Rationale
Ratelimiter is enabled by default to prevent ceresmeta from being hung.

## Detailed Changes
Ratelimiter is enabled by default.

## Test Plan
CI.