### PR TITLE
refactor: procedure storage

### DIFF
--- a/config/example-standalone.toml
+++ b/config/example-standalone.toml
@@ -20,7 +20,7 @@ client-urls = "http://127.0.0.1:2379"
 data-dir = "/tmp/meta0"
 node-name = "meta0"
 initial-cluster = "meta0=http://127.0.0.1:2380"
-default-cluster-node-count = 2
+default-cluster-node-count = 1
 
 [log]
 level = "info"

--- a/server/coordinator/factory.go
+++ b/server/coordinator/factory.go
@@ -95,7 +95,7 @@ type CreatePartitionTableRequest struct {
 
 type BatchRequest struct {
 	Batch     []procedure.Procedure
-	BatchType procedure.Typ
+	BatchType procedure.Kind
 }
 
 func NewFactory(logger *zap.Logger, allocator id.Allocator, dispatch eventdispatch.Dispatch, storage procedure.Storage) *Factory {

--- a/server/coordinator/factory_test.go
+++ b/server/coordinator/factory_test.go
@@ -62,7 +62,7 @@ func TestCreateTable(t *testing.T) {
 		OnFailed:    nil,
 	})
 	re.NoError(err)
-	re.Equal(procedure.CreateTable, p.Typ())
+	re.Equal(procedure.CreateTable, p.Kind())
 	re.Equal(procedure.StateInit, string(p.State()))
 
 	// Create partition table procedure.
@@ -85,7 +85,7 @@ func TestCreateTable(t *testing.T) {
 		OnFailed:    nil,
 	})
 	re.NoError(err)
-	re.Equal(procedure.CreatePartitionTable, p.Typ())
+	re.Equal(procedure.CreatePartitionTable, p.Kind())
 	re.Equal(procedure.StateInit, string(p.State()))
 }
 
@@ -144,7 +144,7 @@ func TestTransferLeader(t *testing.T) {
 		NewLeaderNodeName: snapshot.RegisteredNodes[0].Node.Name,
 	})
 	re.NoError(err)
-	re.Equal(procedure.TransferLeader, p.Typ())
+	re.Equal(procedure.TransferLeader, p.Kind())
 	re.Equal(procedure.StateInit, string(p.State()))
 }
 
@@ -163,6 +163,6 @@ func TestSplit(t *testing.T) {
 		TargetNodeName:  snapshot.Topology.ClusterView.ShardNodes[0].NodeName,
 	})
 	re.NoError(err)
-	re.Equal(procedure.Split, p.Typ())
+	re.Equal(procedure.Split, p.Kind())
 	re.Equal(procedure.StateInit, string(p.State()))
 }

--- a/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
+++ b/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
@@ -336,7 +336,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
+++ b/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
@@ -128,7 +128,7 @@ func (p *Procedure) ID() uint64 {
 	return p.params.ID
 }
 
-func (p *Procedure) Typ() procedure.Typ {
+func (p *Procedure) Kind() procedure.Kind {
 	return procedure.CreatePartitionTable
 }
 

--- a/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
+++ b/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
@@ -336,7 +336,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
+++ b/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table.go
@@ -374,7 +374,7 @@ func (p *Procedure) convertToMeta() (procedure.Meta, error) {
 
 	meta := procedure.Meta{
 		ID:    p.params.ID,
-		Typ:   procedure.CreatePartitionTable,
+		Kind:  procedure.CreatePartitionTable,
 		State: p.state,
 
 		RawData: rawDataBytes,

--- a/server/coordinator/procedure/ddl/createtable/create_table.go
+++ b/server/coordinator/procedure/ddl/createtable/create_table.go
@@ -207,7 +207,7 @@ func (p *Procedure) ID() uint64 {
 	return p.params.ID
 }
 
-func (p *Procedure) Typ() procedure.Typ {
+func (p *Procedure) Kind() procedure.Kind {
 	return procedure.CreateTable
 }
 

--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -143,7 +143,7 @@ func (p *Procedure) ID() uint64 {
 	return p.params.ID
 }
 
-func (p *Procedure) Typ() procedure.Typ {
+func (p *Procedure) Kind() procedure.Kind {
 	return procedure.DropPartitionTable
 }
 

--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -254,7 +254,7 @@ func (p *Procedure) convertToMeta() (procedure.Meta, error) {
 
 	meta := procedure.Meta{
 		ID:    p.params.ID,
-		Typ:   procedure.DropPartitionTable,
+		Kind:  procedure.DropPartitionTable,
 		State: p.state,
 
 		RawData: rawDataBytes,

--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -229,7 +229,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -229,7 +229,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/ddl/droptable/drop_table.go
+++ b/server/coordinator/procedure/ddl/droptable/drop_table.go
@@ -244,7 +244,7 @@ func (p *Procedure) ID() uint64 {
 	return p.params.ID
 }
 
-func (p *Procedure) Typ() procedure.Typ {
+func (p *Procedure) Kind() procedure.Kind {
 	return procedure.DropTable
 }
 

--- a/server/coordinator/procedure/delay_queue_test.go
+++ b/server/coordinator/procedure/delay_queue_test.go
@@ -43,7 +43,7 @@ func (t TestProcedure) ID() uint64 {
 	return t.ProcedureID
 }
 
-func (t TestProcedure) Typ() Typ {
+func (t TestProcedure) Kind() Kind {
 	return CreateTable
 }
 

--- a/server/coordinator/procedure/manager_impl.go
+++ b/server/coordinator/procedure/manager_impl.go
@@ -112,7 +112,7 @@ func (m *ManagerImpl) ListRunningProcedure(_ context.Context) ([]*Info, error) {
 		if procedure.State() == StateRunning {
 			procedureInfos = append(procedureInfos, &Info{
 				ID:    procedure.ID(),
-				Typ:   procedure.Kind(),
+				Kind:  procedure.Kind(),
 				State: procedure.State(),
 			})
 		}

--- a/server/coordinator/procedure/manager_impl.go
+++ b/server/coordinator/procedure/manager_impl.go
@@ -112,7 +112,7 @@ func (m *ManagerImpl) ListRunningProcedure(_ context.Context) ([]*Info, error) {
 		if procedure.State() == StateRunning {
 			procedureInfos = append(procedureInfos, &Info{
 				ID:    procedure.ID(),
-				Typ:   procedure.Typ(),
+				Typ:   procedure.Kind(),
 				State: procedure.State(),
 			})
 		}

--- a/server/coordinator/procedure/manager_test.go
+++ b/server/coordinator/procedure/manager_test.go
@@ -39,7 +39,7 @@ func (m *MockProcedure) ID() uint64 {
 	return m.id
 }
 
-func (m *MockProcedure) Typ() procedure.Typ {
+func (m *MockProcedure) Kind() procedure.Kind {
 	return procedure.CreateTable
 }
 

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -323,7 +323,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -170,7 +170,7 @@ func (p *Procedure) ID() uint64 {
 	return p.params.ID
 }
 
-func (p *Procedure) Typ() procedure.Typ {
+func (p *Procedure) Kind() procedure.Kind {
 	return procedure.Split
 }
 

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -323,7 +323,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -357,7 +357,7 @@ func (p *Procedure) convertToMeta() (procedure.Meta, error) {
 
 	meta := procedure.Meta{
 		ID:    p.params.ID,
-		Typ:   procedure.Split,
+		Kind:  procedure.Split,
 		State: p.state,
 
 		RawData: rawDataBytes,

--- a/server/coordinator/procedure/operation/transferleader/batch_transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/batch_transfer_leader.go
@@ -99,7 +99,7 @@ func (p *BatchTransferLeaderProcedure) ID() uint64 {
 	return p.id
 }
 
-func (p *BatchTransferLeaderProcedure) Typ() procedure.Typ {
+func (p *BatchTransferLeaderProcedure) Kind() procedure.Kind {
 	return procedure.TransferLeader
 }
 

--- a/server/coordinator/procedure/operation/transferleader/batch_transfer_leader_test.go
+++ b/server/coordinator/procedure/operation/transferleader/batch_transfer_leader_test.go
@@ -29,7 +29,7 @@ import (
 type mockProcedure struct {
 	ClusterID        storage.ClusterID
 	clusterVersion   uint64
-	typ              procedure.Typ
+	typ              procedure.Kind
 	ShardWithVersion map[storage.ShardID]uint64
 }
 
@@ -37,7 +37,7 @@ func (m mockProcedure) ID() uint64 {
 	return 0
 }
 
-func (m mockProcedure) Typ() procedure.Typ {
+func (m mockProcedure) Kind() procedure.Kind {
 	return m.typ
 }
 
@@ -93,7 +93,7 @@ func TestBatchProcedure(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		shardWithVersion := map[storage.ShardID]uint64{}
 		shardWithVersion[storage.ShardID(i)] = 0
-		p := CreateMockProcedure(0, 0, procedure.Typ(i), shardWithVersion)
+		p := CreateMockProcedure(0, 0, procedure.Kind(i), shardWithVersion)
 		procedures = append(procedures, p)
 	}
 	_, err = transferleader.NewBatchTransferLeaderProcedure(0, procedures)
@@ -103,14 +103,14 @@ func TestBatchProcedure(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		shardWithVersion := map[storage.ShardID]uint64{}
 		shardWithVersion[storage.ShardID(0)] = uint64(i)
-		p := CreateMockProcedure(0, 0, procedure.Typ(i), shardWithVersion)
+		p := CreateMockProcedure(0, 0, procedure.Kind(i), shardWithVersion)
 		procedures = append(procedures, p)
 	}
 	_, err = transferleader.NewBatchTransferLeaderProcedure(0, procedures)
 	re.Error(err)
 }
 
-func CreateMockProcedure(clusterID storage.ClusterID, clusterVersion uint64, typ procedure.Typ, shardWithVersion map[storage.ShardID]uint64) procedure.Procedure {
+func CreateMockProcedure(clusterID storage.ClusterID, clusterVersion uint64, typ procedure.Kind, shardWithVersion map[storage.ShardID]uint64) procedure.Procedure {
 	return mockProcedure{
 		ClusterID:        clusterID,
 		clusterVersion:   clusterVersion,

--- a/server/coordinator/procedure/operation/transferleader/batch_transfer_leader_test.go
+++ b/server/coordinator/procedure/operation/transferleader/batch_transfer_leader_test.go
@@ -29,7 +29,7 @@ import (
 type mockProcedure struct {
 	ClusterID        storage.ClusterID
 	clusterVersion   uint64
-	typ              procedure.Kind
+	kind             procedure.Kind
 	ShardWithVersion map[storage.ShardID]uint64
 }
 
@@ -38,7 +38,7 @@ func (m mockProcedure) ID() uint64 {
 }
 
 func (m mockProcedure) Kind() procedure.Kind {
-	return m.typ
+	return m.kind
 }
 
 func (m mockProcedure) Start(_ context.Context) error {
@@ -114,7 +114,7 @@ func CreateMockProcedure(clusterID storage.ClusterID, clusterVersion uint64, typ
 	return mockProcedure{
 		ClusterID:        clusterID,
 		clusterVersion:   clusterVersion,
-		typ:              typ,
+		kind:             typ,
 		ShardWithVersion: shardWithVersion,
 	}
 }

--- a/server/coordinator/procedure/operation/transferleader/transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/transfer_leader.go
@@ -348,7 +348,7 @@ func (p *Procedure) convertToMeta() (procedure.Meta, error) {
 
 	meta := procedure.Meta{
 		ID:    p.params.ID,
-		Typ:   procedure.TransferLeader,
+		Kind:  procedure.TransferLeader,
 		State: p.state,
 
 		RawData: rawDataBytes,

--- a/server/coordinator/procedure/operation/transferleader/transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/transfer_leader.go
@@ -171,7 +171,7 @@ func (p *Procedure) ID() uint64 {
 	return p.params.ID
 }
 
-func (p *Procedure) Typ() procedure.Typ {
+func (p *Procedure) Kind() procedure.Kind {
 	return procedure.TransferLeader
 }
 

--- a/server/coordinator/procedure/operation/transferleader/transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/transfer_leader.go
@@ -233,7 +233,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/operation/transferleader/transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/transfer_leader.go
@@ -233,7 +233,7 @@ func (p *Procedure) persist(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "convert to meta")
 	}
-	err = p.params.Storage.CreateOrUpdate(ctx, meta, 0)
+	err = p.params.Storage.CreateOrUpdate(ctx, meta)
 	if err != nil {
 		return errors.WithMessage(err, "createOrUpdate procedure storage")
 	}

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -32,11 +32,11 @@ const (
 	StateCancelled = "cancelled"
 )
 
-type Typ uint
+type Kind uint
 
 const (
 	// Cluster Operation
-	Create Typ = iota
+	Create Kind = iota
 	Delete
 	TransferLeader
 	Migrate
@@ -65,8 +65,8 @@ type Procedure interface {
 	// ID of the procedure.
 	ID() uint64
 
-	// Typ of the procedure.
-	Typ() Typ
+	// Kind of the procedure.
+	Kind() Kind
 
 	// Start the procedure.
 	Start(ctx context.Context) error
@@ -87,7 +87,7 @@ type Procedure interface {
 // Info is used to provide immutable description procedure information.
 type Info struct {
 	ID    uint64
-	Typ   Typ
+	Typ   Kind
 	State State
 }
 

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -87,7 +87,7 @@ type Procedure interface {
 // Info is used to provide immutable description procedure information.
 type Info struct {
 	ID    uint64
-	Typ   Kind
+	Kind  Kind
 	State State
 }
 

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -21,7 +21,8 @@ import (
 )
 
 type Write interface {
-	CreateOrUpdate(ctx context.Context, meta Meta, ttlSec int64) error
+	CreateOrUpdate(ctx context.Context, meta Meta) error
+	CreateOrUpdateWithTTL(ctx context.Context, meta Meta, ttlSec int64) error
 }
 
 type Meta struct {

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Write interface {
-	CreateOrUpdate(ctx context.Context, meta Meta, ttl int64) error
+	CreateOrUpdate(ctx context.Context, meta Meta, ttlSec int64) error
 }
 
 type Meta struct {

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Write interface {
-	CreateOrUpdate(ctx context.Context, meta Meta) error
+	CreateOrUpdate(ctx context.Context, meta Meta, ttl int64) error
 }
 
 type Meta struct {
@@ -33,6 +33,7 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	List(ctx context.Context, batchSize int) ([]*Meta, error)
-	MarkDeleted(ctx context.Context, id uint64) error
+	List(ctx context.Context, procedureType Typ, batchSize int) ([]*Meta, error)
+	Delete(ctx context.Context, procedureType Typ, id uint64) error
+	MarkDeleted(ctx context.Context, procedureType Typ, id uint64) error
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -27,7 +27,7 @@ type Write interface {
 
 type Meta struct {
 	ID      uint64
-	Typ     Kind
+	Kind    Kind
 	State   State
 	RawData []byte
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -27,14 +27,14 @@ type Write interface {
 
 type Meta struct {
 	ID      uint64
-	Typ     Typ
+	Typ     Kind
 	State   State
 	RawData []byte
 }
 
 type Storage interface {
 	Write
-	List(ctx context.Context, procedureType Typ, batchSize int) ([]*Meta, error)
-	Delete(ctx context.Context, procedureType Typ, id uint64) error
-	MarkDeleted(ctx context.Context, procedureType Typ, id uint64) error
+	List(ctx context.Context, procedureType Kind, batchSize int) ([]*Meta, error)
+	Delete(ctx context.Context, procedureType Kind, id uint64) error
+	MarkDeleted(ctx context.Context, procedureType Kind, id uint64) error
 }

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -55,7 +55,7 @@ func NewEtcdStorageImpl(client *clientv3.Client, rootPath string, clusterID uint
 // CreateOrUpdate example:
 // /{rootPath}/v1/procedure/{procedureType}/{procedureID} ->  {procedureState} + {data}
 // ttl is only valid when greater than 0, if it is less than or equal to 0, it will be ignored.
-func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta Meta, ttl int64) error {
+func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta Meta, ttlSec int64) error {
 	s, err := encode(&meta)
 	if err != nil {
 		return errors.WithMessage(err, "encode meta failed")
@@ -64,11 +64,11 @@ func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta Meta, ttl int6
 	keyPath := e.generaNormalKeyPath(meta.Typ, meta.ID)
 
 	var opPut clientv3.Op
-	if ttl <= 0 {
+	if ttlSec <= 0 {
 		opPut = clientv3.OpPut(keyPath, s)
 	} else {
 		// TODO: This implementation will cause each procedure to correspond to an etcd lease, which may cause too much pressure on etcd? May need to optimize implementation.
-		resp, err := e.client.Grant(ctx, ttl)
+		resp, err := e.client.Grant(ctx, ttlSec)
 		if err != nil {
 			return errors.WithMessage(err, "etcd get lease failed")
 		}

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -22,10 +22,14 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"strconv"
 
+	"github.com/CeresDB/horaemeta/pkg/log"
 	"github.com/CeresDB/horaemeta/server/etcdutil"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/clientv3util"
+	"go.uber.org/zap"
 )
 
 const (
@@ -49,31 +53,66 @@ func NewEtcdStorageImpl(client *clientv3.Client, rootPath string, clusterID uint
 }
 
 // CreateOrUpdate example:
-// /{rootPath}/v1/procedure/{procedureID} -> {procedureType} + {procedureState} + {data}
-func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta Meta) error {
+// /{rootPath}/v1/procedure/{procedureType}/{procedureID} ->  {procedureState} + {data}
+// ttl is only valid when greater than 0, if it is less than or equal to 0, it will be ignored.
+func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta Meta, ttl int64) error {
 	s, err := encode(&meta)
 	if err != nil {
 		return errors.WithMessage(err, "encode meta failed")
 	}
-	keyPath := e.generaNormalKeyPath(meta.ID)
-	opPut := clientv3.OpPut(keyPath, s)
+
+	keyPath := e.generaNormalKeyPath(meta.Typ, meta.ID)
+
+	var opPut clientv3.Op
+	if ttl <= 0 {
+		opPut = clientv3.OpPut(keyPath, s)
+	} else {
+		// TODO: This implementation will cause each procedure to correspond to an etcd lease, which may cause too much pressure on etcd? May need to optimize implementation.
+		resp, err := e.client.Grant(ctx, ttl)
+		if err != nil {
+			return errors.WithMessage(err, "etcd get lease failed")
+		}
+		opPut = clientv3.OpPut(keyPath, s, clientv3.WithLease(resp.ID))
+	}
 
 	if _, err = e.client.Do(ctx, opPut); err != nil {
 		return errors.WithMessage(err, "etcd put data failed")
 	}
+
+	return nil
+}
+
+// Delete will delete the specified procedure,
+// and try to delete its corresponding history procedure if it exists.
+func (e EtcdStorageImpl) Delete(ctx context.Context, procedureType Typ, id uint64) error {
+	keyPath := e.generaNormalKeyPath(procedureType, id)
+	opDelete := clientv3.OpDelete(keyPath)
+
+	if _, err := e.client.Txn(ctx).Then(opDelete).Commit(); err != nil {
+		return err
+	}
+
+	deletedKeyPath := e.generaDeletedKeyPath(procedureType, id)
+	opDeleteMark := clientv3.OpDelete(deletedKeyPath)
+	// Try to delete history procedure if it exists.
+	keyExists := clientv3util.KeyExists(deletedKeyPath)
+	if _, err := e.client.Txn(ctx).If(keyExists).Then(opDeleteMark).Commit(); err != nil {
+		log.Warn("drop history procedure failed", zap.String("deletedKeyPath", deletedKeyPath), zap.Error(err))
+	}
+
 	return nil
 }
 
 // MarkDeleted Do a soft deletion, and the deleted key's format is:
 // /{rootPath}/v1/historyProcedure/{clusterID}/{procedureID}
-func (e EtcdStorageImpl) MarkDeleted(ctx context.Context, id uint64) error {
-	keyPath := e.generaNormalKeyPath(id)
+func (e EtcdStorageImpl) MarkDeleted(ctx context.Context, procedureType Typ, id uint64) error {
+	keyPath := e.generaNormalKeyPath(procedureType, id)
 	meta, err := etcdutil.Get(ctx, e.client, keyPath)
 	if err != nil {
 		return errors.WithMessage(err, "get meta failed")
 	}
 
-	deletedKeyPath := e.generaDeletedKeyPath(id)
+	deletedKeyPath := e.generaDeletedKeyPath(procedureType, id)
 	opDelete := clientv3.OpDelete(keyPath)
 	opPut := clientv3.OpPut(deletedKeyPath, meta)
 
@@ -82,7 +121,7 @@ func (e EtcdStorageImpl) MarkDeleted(ctx context.Context, id uint64) error {
 	return err
 }
 
-func (e EtcdStorageImpl) List(ctx context.Context, batchSize int) ([]*Meta, error) {
+func (e EtcdStorageImpl) List(ctx context.Context, procedureType Typ, batchSize int) ([]*Meta, error) {
 	var metas []*Meta
 	do := func(key string, value []byte) error {
 		meta, err := decodeMeta(string(value))
@@ -94,8 +133,8 @@ func (e EtcdStorageImpl) List(ctx context.Context, batchSize int) ([]*Meta, erro
 		return nil
 	}
 
-	startKey := e.generaNormalKeyPath(uint64(0))
-	endKey := e.generaNormalKeyPath(math.MaxUint64)
+	startKey := e.generaNormalKeyPath(procedureType, uint64(0))
+	endKey := e.generaNormalKeyPath(procedureType, math.MaxUint64)
 
 	err := etcdutil.Scan(ctx, e.client, startKey, endKey, batchSize, do)
 	if err != nil {
@@ -104,22 +143,22 @@ func (e EtcdStorageImpl) List(ctx context.Context, batchSize int) ([]*Meta, erro
 	return metas, nil
 }
 
-func (e EtcdStorageImpl) generaNormalKeyPath(procedureID uint64) string {
-	return e.generateKeyPath(procedureID, false)
+func (e EtcdStorageImpl) generaNormalKeyPath(procedureType Typ, procedureID uint64) string {
+	return e.generateKeyPath(procedureID, procedureType, false)
 }
 
-func (e EtcdStorageImpl) generaDeletedKeyPath(procedureID uint64) string {
-	return e.generateKeyPath(procedureID, true)
+func (e EtcdStorageImpl) generaDeletedKeyPath(procedureType Typ, procedureID uint64) string {
+	return e.generateKeyPath(procedureID, procedureType, true)
 }
 
-func (e EtcdStorageImpl) generateKeyPath(procedureID uint64, isDeleted bool) string {
+func (e EtcdStorageImpl) generateKeyPath(procedureID uint64, procedureType Typ, isDeleted bool) string {
 	var procedurePath string
 	if isDeleted {
 		procedurePath = PathDeletedProcedure
 	} else {
 		procedurePath = PathProcedure
 	}
-	return path.Join(e.rootPath, Version, procedurePath, fmtID(uint64(e.clusterID)), fmtID(procedureID))
+	return path.Join(e.rootPath, Version, procedurePath, fmtID(uint64(e.clusterID)), strconv.Itoa(int(procedureType)), fmtID(procedureID))
 }
 
 func fmtID(id uint64) string {

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -61,7 +61,7 @@ func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta Meta) error {
 		return errors.WithMessage(err, "encode meta failed")
 	}
 
-	keyPath := e.generaNormalKeyPath(meta.Typ, meta.ID)
+	keyPath := e.generaNormalKeyPath(meta.Kind, meta.ID)
 
 	opPut := clientv3.OpPut(keyPath, s)
 
@@ -80,7 +80,7 @@ func (e EtcdStorageImpl) CreateOrUpdateWithTTL(ctx context.Context, meta Meta, t
 		return errors.WithMessage(err, "encode meta failed")
 	}
 
-	keyPath := e.generaNormalKeyPath(meta.Typ, meta.ID)
+	keyPath := e.generaNormalKeyPath(meta.Kind, meta.ID)
 
 	// TODO: This implementation will cause each procedure to correspond to an etcd lease, which may cause too much pressure on etcd? May need to optimize implementation.
 	resp, err := e.client.Grant(ctx, ttlSec)

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -97,7 +97,7 @@ func (e EtcdStorageImpl) CreateOrUpdateWithTTL(ctx context.Context, meta Meta, t
 }
 
 // Delete will delete the specified procedure, and try to delete its corresponding history procedure if it exists.
-func (e EtcdStorageImpl) Delete(ctx context.Context, procedureType Typ, id uint64) error {
+func (e EtcdStorageImpl) Delete(ctx context.Context, procedureType Kind, id uint64) error {
 	keyPath := e.generaNormalKeyPath(procedureType, id)
 	opDelete := clientv3.OpDelete(keyPath)
 
@@ -118,7 +118,7 @@ func (e EtcdStorageImpl) Delete(ctx context.Context, procedureType Typ, id uint6
 
 // MarkDeleted Do a soft deletion, and the deleted key's format is:
 // /{rootPath}/v1/historyProcedure/{clusterID}/{procedureID}
-func (e EtcdStorageImpl) MarkDeleted(ctx context.Context, procedureType Typ, id uint64) error {
+func (e EtcdStorageImpl) MarkDeleted(ctx context.Context, procedureType Kind, id uint64) error {
 	keyPath := e.generaNormalKeyPath(procedureType, id)
 	meta, err := etcdutil.Get(ctx, e.client, keyPath)
 	if err != nil {
@@ -134,7 +134,7 @@ func (e EtcdStorageImpl) MarkDeleted(ctx context.Context, procedureType Typ, id 
 	return err
 }
 
-func (e EtcdStorageImpl) List(ctx context.Context, procedureType Typ, batchSize int) ([]*Meta, error) {
+func (e EtcdStorageImpl) List(ctx context.Context, procedureType Kind, batchSize int) ([]*Meta, error) {
 	var metas []*Meta
 	do := func(key string, value []byte) error {
 		meta, err := decodeMeta(string(value))
@@ -156,15 +156,15 @@ func (e EtcdStorageImpl) List(ctx context.Context, procedureType Typ, batchSize 
 	return metas, nil
 }
 
-func (e EtcdStorageImpl) generaNormalKeyPath(procedureType Typ, procedureID uint64) string {
+func (e EtcdStorageImpl) generaNormalKeyPath(procedureType Kind, procedureID uint64) string {
 	return e.generateKeyPath(procedureID, procedureType, false)
 }
 
-func (e EtcdStorageImpl) generaDeletedKeyPath(procedureType Typ, procedureID uint64) string {
+func (e EtcdStorageImpl) generaDeletedKeyPath(procedureType Kind, procedureID uint64) string {
 	return e.generateKeyPath(procedureID, procedureType, true)
 }
 
-func (e EtcdStorageImpl) generateKeyPath(procedureID uint64, procedureType Typ, isDeleted bool) string {
+func (e EtcdStorageImpl) generateKeyPath(procedureID uint64, procedureType Kind, isDeleted bool) string {
 	var procedurePath string
 	if isDeleted {
 		procedurePath = PathDeletedProcedure

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -39,7 +39,7 @@ func testWrite(t *testing.T, storage Storage) {
 
 	testMeta1 := Meta{
 		ID:      uint64(1),
-		Typ:     TransferLeader,
+		Kind:    TransferLeader,
 		State:   StateInit,
 		RawData: []byte("test"),
 	}
@@ -50,7 +50,7 @@ func testWrite(t *testing.T, storage Storage) {
 
 	testMeta2 := Meta{
 		ID:      uint64(2),
-		Typ:     TransferLeader,
+		Kind:    TransferLeader,
 		State:   StateInit,
 		RawData: []byte("test"),
 	}
@@ -82,7 +82,7 @@ func testDelete(t *testing.T, storage Storage) {
 
 	testMeta1 := &Meta{
 		ID:      uint64(1),
-		Typ:     TransferLeader,
+		Kind:    TransferLeader,
 		State:   StateInit,
 		RawData: []byte("test"),
 	}
@@ -95,7 +95,7 @@ func testDelete(t *testing.T, storage Storage) {
 
 	testMeta2 := Meta{
 		ID:      uint64(2),
-		Typ:     TransferLeader,
+		Kind:    TransferLeader,
 		State:   StateInit,
 		RawData: []byte("test"),
 	}

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -45,7 +45,7 @@ func testWrite(t *testing.T, storage Storage) {
 	}
 
 	// Test create new procedure
-	err := storage.CreateOrUpdate(ctx, testMeta1, 0)
+	err := storage.CreateOrUpdate(ctx, testMeta1)
 	re.NoError(err)
 
 	testMeta2 := Meta{
@@ -54,12 +54,12 @@ func testWrite(t *testing.T, storage Storage) {
 		State:   StateInit,
 		RawData: []byte("test"),
 	}
-	err = storage.CreateOrUpdate(ctx, testMeta2, 0)
+	err = storage.CreateOrUpdate(ctx, testMeta2)
 	re.NoError(err)
 
 	// Test update procedure
 	testMeta2.RawData = []byte("test update")
-	err = storage.CreateOrUpdate(ctx, testMeta2, 0)
+	err = storage.CreateOrUpdate(ctx, testMeta2)
 	re.NoError(err)
 }
 

--- a/server/coordinator/procedure/test/common.go
+++ b/server/coordinator/procedure/test/common.go
@@ -87,15 +87,15 @@ func (m MockStorage) CreateOrUpdateWithTTL(_ context.Context, _ procedure.Meta, 
 	return nil
 }
 
-func (m MockStorage) List(_ context.Context, _ procedure.Typ, _ int) ([]*procedure.Meta, error) {
+func (m MockStorage) List(_ context.Context, _ procedure.Kind, _ int) ([]*procedure.Meta, error) {
 	return nil, nil
 }
 
-func (m MockStorage) Delete(_ context.Context, _ procedure.Typ, _ uint64) error {
+func (m MockStorage) Delete(_ context.Context, _ procedure.Kind, _ uint64) error {
 	return nil
 }
 
-func (m MockStorage) MarkDeleted(_ context.Context, _ procedure.Typ, _ uint64) error {
+func (m MockStorage) MarkDeleted(_ context.Context, _ procedure.Kind, _ uint64) error {
 	return nil
 }
 

--- a/server/coordinator/procedure/test/common.go
+++ b/server/coordinator/procedure/test/common.go
@@ -79,15 +79,19 @@ func (m MockDispatch) CloseTableOnShard(_ context.Context, _ string, _ eventdisp
 
 type MockStorage struct{}
 
-func (m MockStorage) CreateOrUpdate(_ context.Context, _ procedure.Meta) error {
+func (m MockStorage) CreateOrUpdate(_ context.Context, _ procedure.Meta, _ int64) error {
 	return nil
 }
 
-func (m MockStorage) List(_ context.Context, _ int) ([]*procedure.Meta, error) {
+func (m MockStorage) List(_ context.Context, _ procedure.Typ, _ int) ([]*procedure.Meta, error) {
 	return nil, nil
 }
 
-func (m MockStorage) MarkDeleted(_ context.Context, _ uint64) error {
+func (m MockStorage) Delete(_ context.Context, _ procedure.Typ, _ uint64) error {
+	return nil
+}
+
+func (m MockStorage) MarkDeleted(_ context.Context, _ procedure.Typ, _ uint64) error {
 	return nil
 }
 

--- a/server/coordinator/procedure/test/common.go
+++ b/server/coordinator/procedure/test/common.go
@@ -79,7 +79,11 @@ func (m MockDispatch) CloseTableOnShard(_ context.Context, _ string, _ eventdisp
 
 type MockStorage struct{}
 
-func (m MockStorage) CreateOrUpdate(_ context.Context, _ procedure.Meta, _ int64) error {
+func (m MockStorage) CreateOrUpdate(_ context.Context, _ procedure.Meta) error {
+	return nil
+}
+
+func (m MockStorage) CreateOrUpdateWithTTL(_ context.Context, _ procedure.Meta, _ int64) error {
 	return nil
 }
 

--- a/server/id/id_impl.go
+++ b/server/id/id_impl.go
@@ -92,6 +92,7 @@ func (a *AllocatorImpl) Collect(_ context.Context, _ uint64) error {
 func (a *AllocatorImpl) slowRebaseLocked(ctx context.Context) error {
 	resp, err := a.kv.Get(ctx, a.key)
 	if err != nil {
+		a.logger.Error("get end id", zap.String("resp", fmt.Sprintf("%v", resp)), zap.String("key", a.key))
 		return errors.WithMessagef(err, "get end id failed, key:%s", a.key)
 	}
 


### PR DESCRIPTION
## Rationale
The current design of the procedure storage module is unreasonable. The data will be stored permanently and will not be cleared. This will cause the storage space of `ETCD` to be filled up quickly. We need to redesign the interface of procedure storage.

## Detailed Changes
* Add `ttl` config for `CreateOrUpdate`.
* Add `Delete` interface, it used to delete history procedure data and current procedure data.

## Test Plan
Pass all unit tests and integration tests.