### PR TITLE
fix: wrong procedure id allocator

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"strings"
 
 	"github.com/CeresDB/horaemeta/server/cluster/metadata"
 	"github.com/CeresDB/horaemeta/server/coordinator"
@@ -32,8 +33,8 @@ import (
 )
 
 const (
-	defaultProcedurePrefixKey = "procedure"
-	defaultAllocStep          = 5
+	defaultProcedurePrefixKey = "ProcedureID"
+	defaultAllocStep          = 50
 )
 
 type Cluster struct {
@@ -52,7 +53,7 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 		return nil, errors.WithMessage(err, "create procedure manager")
 	}
 	dispatch := eventdispatch.NewDispatchImpl()
-	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
+	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, strings.Join([]string{rootPath, metadata.Name(), defaultProcedurePrefixKey}, "/"), defaultAllocStep), dispatch, procedureStorage)
 
 	schedulerManager := manager.NewManager(logger, procedureManager, procedureFactory, metadata, client, rootPath, metadata.GetTopologyType(), metadata.GetProcedureExecutingBatchSize())
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -53,7 +53,9 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 		return nil, errors.WithMessage(err, "create procedure manager")
 	}
 	dispatch := eventdispatch.NewDispatchImpl()
-	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, strings.Join([]string{rootPath, metadata.Name(), defaultProcedurePrefixKey}, "/"), defaultAllocStep), dispatch, procedureStorage)
+
+	procedureIDRootPath := strings.Join([]string{rootPath, metadata.Name(), defaultProcedurePrefixKey}, "/")
+	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, procedureIDRootPath, defaultAllocStep), dispatch, procedureStorage)
 
 	schedulerManager := manager.NewManager(logger, procedureManager, procedureFactory, metadata, client, rootPath, metadata.GetTopologyType(), metadata.GetProcedureExecutingBatchSize())
 

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -302,7 +302,8 @@ func (a *API) createCluster(req *http.Request) apiFuncResult {
 		log.Error("parse topology type failed", zap.Error(err))
 		return errResult(ErrParseRequest, err.Error())
 	}
-	c, err := a.clusterManager.CreateCluster(req.Context(), createClusterRequest.Name, metadata.CreateClusterOpts{
+
+	c, err := a.clusterManager.CreateCluster(context.Background(), createClusterRequest.Name, metadata.CreateClusterOpts{
 		NodeCount:                   createClusterRequest.NodeCount,
 		ShardTotal:                  createClusterRequest.ShardTotal,
 		EnableSchedule:              createClusterRequest.EnableSchedule,

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -303,13 +303,15 @@ func (a *API) createCluster(req *http.Request) apiFuncResult {
 		return errResult(ErrParseRequest, err.Error())
 	}
 
-	c, err := a.clusterManager.CreateCluster(context.Background(), createClusterRequest.Name, metadata.CreateClusterOpts{
+	ctx := context.Background()
+	createClusterOpts := metadata.CreateClusterOpts{
 		NodeCount:                   createClusterRequest.NodeCount,
 		ShardTotal:                  createClusterRequest.ShardTotal,
 		EnableSchedule:              createClusterRequest.EnableSchedule,
 		TopologyType:                topologyType,
 		ProcedureExecutingBatchSize: createClusterRequest.ProcedureExecutingBatchSize,
-	})
+	}
+	c, err := a.clusterManager.CreateCluster(ctx, createClusterRequest.Name, createClusterOpts)
 	if err != nil {
 		log.Error("create cluster failed", zap.Error(err))
 		return errResult(metadata.ErrCreateCluster, err.Error())


### PR DESCRIPTION
## Rationale
Due to misconfiguration of the ProcedureID Allocator storage path in ETCD, multiple clusters will share the same ProcedureID Allocator, which will cause ID to be wasted.

## Detailed Changes
* Fix wrong ID allocator storage path.

## Test Plan
Pass CI.