### PR TITLE
chore: rename comment's ceresdb to horaedb

### DIFF
--- a/server/id/id.go
+++ b/server/id/id.go
@@ -18,7 +18,7 @@ package id
 
 import "context"
 
-// Allocator defines the id allocator on the ceresdb cluster meta info.
+// Allocator defines the id allocator on the horaedb cluster meta info.
 type Allocator interface {
 	// Alloc allocs a unique id.
 	Alloc(ctx context.Context) (uint64, error)


### PR DESCRIPTION
## Rationale
related https://github.com/CeresDB/horaedb/issues/1319

## Detailed Changes
rename comment's ceresdb to horaedb

## Test Plan
ci